### PR TITLE
 Added the ability to configure the Satcom antenna gain

### DIFF
--- a/y/tfw_radios/addons/rf3080/XEH_preInit.sqf
+++ b/y/tfw_radios/addons/rf3080/XEH_preInit.sqf
@@ -9,3 +9,12 @@ PREP_RECOMPILE_END;
 #include "\a3\ui_f\hpp\defineDIKCodes.inc"
 
 ADDON = true;
+
+[
+    "ILBE_satcom_gain", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    "ILBE Satcom Gain", // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    "ILBE", // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [1, 1000, 4, 0], // data for this setting: [min, max, default, number of shown trailing decimals]
+    nil // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+] call CBA_fnc_addSetting;

--- a/y/tfw_radios/addons/rf3080/scripts/fn_distanceMultiplicator.sqf
+++ b/y/tfw_radios/addons/rf3080/scripts/fn_distanceMultiplicator.sqf
@@ -19,7 +19,7 @@
 [{
     private _object = getPos player nearestObject "tfw_rf3080Object";
     if ((_object distance player) < 6) then {
-		player setVariable ['tf_sendingDistanceMultiplicator', 4, true];
+		player setVariable ['tf_sendingDistanceMultiplicator', ILBE_satcom_gain, true];
 	} else {
         player setVariable ['tf_sendingDistanceMultiplicator', 1, true];
 	};


### PR DESCRIPTION
Using https://github.com/CBATeam/CBA_A3/wiki/CBA-Settings-System
This will add a page similar to the already used by TFAR like this 
![immagine](https://user-images.githubusercontent.com/368572/194934675-61e7b2e6-b90e-4cd1-b867-90bfcc4ec2d3.png)

The default value has been left to 4,  maximum value I put is 1000, to be totally sure even in super massive map the satcom can guarantee a proper communication.

It can be put lower, if you want to... simulate a faulty one ?

It is still in test stage, so please wait a bit more to merge (even I am 99.9999% will work fine)